### PR TITLE
Add instance of Imp.Num

### DIFF
--- a/integers.opam
+++ b/integers.opam
@@ -18,6 +18,7 @@ build: [
 depends: [
   "ocaml" {>= "4.02"}
   "dune" {build}
+  "imp"
 ]
 
 synopsis: "Various signed and unsigned integer types for OCaml"

--- a/src/dune
+++ b/src/dune
@@ -4,4 +4,5 @@
  (wrapped false)
  (install_c_headers ocaml_integers)
  (c_names unsigned_stubs)
+ (libraries imp)
  (synopsis "Signed and unsigned integers of various sizes"))

--- a/src/unsigned.ml
+++ b/src/unsigned.ml
@@ -272,3 +272,18 @@ type ushort = UShort.t
 type uint = UInt.t
 type ulong = ULong.t
 type ullong = ULLong.t
+
+implicit module ImpNum(S : S) : Imp.Num.Num =
+struct
+  type t = S.t
+  open S
+  let (+) = add
+  let (-) = sub
+  let ( * ) = mul
+  let (/) = div
+  let zero = zero
+  (* for unsigned integers this will error or underflow *)
+  let (~-) x = zero - x
+  let one = one
+  let of_int = of_int
+end

--- a/src/unsigned.mli
+++ b/src/unsigned.mli
@@ -218,3 +218,5 @@ val of_byte_size : int -> (module S)
     with [b] bytes.
 
     Raise [Invalid_argument] if no suitable type is available. *)
+
+implicit module ImpNum(S : S) : Imp.Num.Num


### PR DESCRIPTION
It compiles, but I'm not sure how to use it, or if it's possible to use it properly.

```
# include Unsigned.ImpNum(Unsigned.UInt64);;
(* ..snip.. *)

# (Unsigned.UInt64.of_int 5) + (Unsigned.UInt64.of_int 6);;
Error: This expression has type Unsigned.UInt64.t
       but an expression was expected of type
         t = Unsigned.ImpNum(Unsigned.UInt64).t
```