### PR TITLE
Install top-level printers with attribute

### DIFF
--- a/src/unsigned.mli
+++ b/src/unsigned.mli
@@ -136,7 +136,7 @@ module type S = sig
   (** Convert the given string to an unsigned integer. Returns [None] if the
       given string is not a valid representation of an unsigned integer. *)
 
-  val pp : Format.formatter -> t -> unit
+  val pp : Format.formatter -> t -> unit [@@ocaml.toplevel_printer]
   (** Output the result of {!to_string} on a formatter. *)
 
   val pp_hex : Format.formatter -> t -> unit

--- a/top/dune
+++ b/top/dune
@@ -2,6 +2,7 @@
  (name integers_top)
  (public_name integers.top)
  (modes byte)
+ (modules Integer_printers)
  (wrapped false)
  (synopsis "toplevel pretty printers")
  (libraries integers compiler-libs))


### PR DESCRIPTION
I noticed when running `dune utop`, I would get the following errors:

```
Unbound value Integer_printers.format_sint.
Unbound value Integer_printers.format_long.
Unbound value Integer_printers.format_llong.
Unbound value Integer_printers.format_uchar.
Unbound value Integer_printers.format_uint8.
Unbound value Integer_printers.format_uint16.
Unbound value Integer_printers.format_uint32.
Unbound value Integer_printers.format_uint64.
Unbound value Integer_printers.format_ushort.
Unbound value Integer_printers.format_uint.
Unbound value Integer_printers.format_ulong.
Unbound value Integer_printers.format_ullong.
```

I couldn’t figure out how to fix `integers.top` to fix this issue, but as of ocaml-community/utop#269 it seems that `utop` automatically installs printers marked with the `[@@ocaml.toplevel_printer]` attribute. Removing the `top` package in favor of this attribute seems to fix the issue:

```
────────────┬─────────────────────────────────────────────────────────────┬─────────────
            │ Welcome to utop version 2.14.0 (using OCaml version 5.1.1)! │
            └─────────────────────────────────────────────────────────────┘

Type #utop_help for help about using utop.

─( 17:23:47 )─< command 0 >──────────────────────────────────────────────{ counter: 0 }─
utop # let x = Unsigned.UInt16.of_int 3;;
val x : Unsigned.uint16 = 3
─( 17:23:47 )─< command 1 >──────────────────────────────────────────────{ counter: 0 }─
utop # Unsigned.UInt16.add x x;;
- : Unsigned.uint16 = 6
─( 17:23:50 )─< command 2 >──────────────────────────────────────────────{ counter: 0 }─
utop #
```

Closes #6.